### PR TITLE
Faster gradient

### DIFF
--- a/src/codegen_helpers.jl
+++ b/src/codegen_helpers.jl
@@ -79,15 +79,8 @@ function monomial_product(::Type{T}, exponent::AbstractVector, coefficient, i::U
             continue
         elseif k == i && e > 1
             pushfirst!(ops, :($e))
-            if e > 2
-                push!(ops, pow(x_(k), e - 1))
-            else
-                # e = 1
-                push!(ops, x_(k))
-            end
-        elseif e == 1
-            push!(ops, x_(k))
-        elseif e > 1
+            push!(ops, pow(x_(k), e - 1))
+        elseif e > 0
             push!(ops, pow(x_(k), e))
         end
     end

--- a/src/codegen_helpers.jl
+++ b/src/codegen_helpers.jl
@@ -68,9 +68,9 @@ end
 Generate the monomial product defined by `exponent` with `ooefficient.`
 If `i` is an `Int` the partial derivative will be generated.
 """
-function monomial_product(::Type{T}, exponent::AbstractVector, coefficient, i::Union{Nothing, Int}=nothing) where T
+function monomial_product(::Type{T}, exponent, coefficient, i::Union{Nothing, Int}=nothing) where T
     if i !== nothing && exponent[i] == 0
-        return :(zero($T))
+        return (:(zero($T)), true)
     end
     ops = []
     push!(ops, coefficient)
@@ -84,12 +84,12 @@ function monomial_product(::Type{T}, exponent::AbstractVector, coefficient, i::U
             push!(ops, pow(x_(k), e))
         end
     end
-    batch_arithmetic_ops(:*, ops)
+    (batch_arithmetic_ops(:*, ops), false)
 end
 
 
-function monomial_product_with_derivatives(::Type{T}, exponent::AbstractVector, coefficient) where T
-    val = monomial_product(T, exponent, coefficient)
+function monomial_product_with_derivatives(::Type{T}, exponent, coefficient) where T
+    val, _ = monomial_product(T, exponent, coefficient)
     dvals = map(1:length(exponent)) do i
         monomial_product(T, exponent, coefficient, i)
     end

--- a/src/evaluate_codegen.jl
+++ b/src/evaluate_codegen.jl
@@ -14,7 +14,7 @@ function generate_evaluate!(exprs, E, ::Type{T}, nvar, nterm) where T
     m, n = size(E)
 
     if n == 1
-        return monomial_product(T, E[:,1], :(c[$nterm]))
+        return first(monomial_product(T, E[:,1], :(c[$nterm])))
     end
 
     if m == 1

--- a/src/gradient_codegen.jl
+++ b/src/gradient_codegen.jl
@@ -6,59 +6,76 @@ This assumes that E is in reverse lexicographic order.
 """
 function generate_gradient(E, ::Type{T}) where T
     exprs = []
-    values = generate_gradient!(exprs, E, T, size(E, 1), 1, true)
-    out = :($(values[1]), SVector($(Expr(:tuple, values[2:end]...))))
+    val, dvals = partial_derivatives!(exprs, E, T, size(E, 1), 1)
+    out = :($(val), SVector($(Expr(:tuple, map(first, dvals)...))))
 
     Expr(:block, exprs..., out)
 end
 
-function generate_gradient!(exprs, E, ::Type{T}, nvar, nterm, final=false) where T
+function term(E::AbstractMatrix, ::Type{T}, nterm) where T
+    @assert size(E, 2) == 1
+
+    monomial_product_with_derivatives(T, E, :(c[$nterm]))
+end
+
+function univariate!(exprs, E::AbstractMatrix, ::Type{T}, nvar, nterm) where T
+    @assert size(E, 1) == 1
+    n = size(E, 2)
+    coeffs = [:(c[$j]) for j=nterm:nterm+n]
+    val, dval = evalpoly_derivative!(exprs, T, @view(E[1,:]), coeffs, x_(nvar))
+
+    val, [(dval, n == 1)]
+end
+
+
+function partial_derivatives!(exprs, E, ::Type{T}, nvar, nterm) where T
     m, n = size(E)
 
     # We only have one Term remaining. So we just evaluate the term and compute all
     # partial derivatives
     if n == 1
-        val, dvals = monomial_product_with_derivatives(T, E[:,1], :(c[$nterm]))
-
-        @gensym c
-        push!(exprs, :($c = $val))
-
-        cs = [c]
-        for dval in dvals
-            @gensym c
-            push!(cs, c)
-            push!(exprs, :($c = $dval))
-        end
-
-        return cs
+        return term(E, T, nterm)
+    elseif m == 1
+        return univariate!(exprs, E, T, nvar, nterm)
     end
 
-    if m == 1
-        coeffs = [:(c[$j]) for j=nterm:nterm+n]
-        val, dval = evalpoly_derivative!(exprs, T, E[1,:], coeffs, x_(nvar))
-        return [val, dval]
-    end
-
-    # Recursive
     degrees, submatrices = degrees_submatrices(E)
-    # For each coefficient we have the actual coefficent plus each partial derivative
-    # of the other variables
-    coeffs = Matrix{Symbol}(undef, length(submatrices), m)
+    values = []
+    dvalues = []
     for (k, E_d) in enumerate(submatrices)
-        coeffs[k, :] = generate_gradient!(exprs, E_d, T, nvar - 1, nterm)
+        val, dvals = partial_derivatives!(exprs, E_d, T, nvar - 1, nterm)
+        push!(values, val)
+        push!(dvalues, dvals)
+
         nterm += size(E_d, 2)
     end
-
     # Now we have to evaluate polynomials
     # for our current variable we need our new partial derivative
-    val, dval = evalpoly_derivative!(exprs, T, degrees, coeffs[:, 1], x_(nvar))
-    values = [val]
-    for k=2:m
-        @gensym c
-        push!(exprs, :($c = $(evalpoly(T, degrees, coeffs[:, k], x_(nvar)))))
-        push!(values, c)
+    val, derivative_val = evalpoly_derivative!(exprs, T, degrees, values, x_(nvar))
+    dvals = []
+    reverse!(dvalues)
+    for k=1:(m-1)
+        coeffs_k = []
+        for dv in dvalues
+            dval, iszero = dv[k]
+            if !isempty(coeffs_k) || !iszero
+                pushfirst!(coeffs_k, dval)
+            end
+        end
+        degrees_k = degrees[1:length(coeffs_k)]
+        # we do not need assign a new variable and call evalpoly
+        # if we just have a degree 0 polynomial with already computed coefficient
+        if length(degrees_k) == 1 && degrees_k[1] == 0 && coeffs_k[1] isa Symbol
+            push!(dvals, (coeffs_k[1], false))
+        elseif length(degrees_k) > 0
+            @gensym c
+            push!(exprs, :($c = $(evalpoly(T, degrees_k, coeffs_k, x_(nvar)))))
+            push!(dvals, (c, false))
+        else
+            push!(dvals, (:(zero($T)), true))
+        end
     end
-    push!(values, dval)
+    push!(dvals, (derivative_val, length(degrees) == 1))
 
-    return values
+    val, dvals
 end

--- a/src/gradient_codegen.jl
+++ b/src/gradient_codegen.jl
@@ -15,6 +15,8 @@ end
 function generate_gradient!(exprs, E, ::Type{T}, nvar, nterm, final=false) where T
     m, n = size(E)
 
+    # We only have one Term remaining. So we just evaluate the term and compute all
+    # partial derivatives
     if n == 1
         val, dvals = monomial_product_with_derivatives(T, E[:,1], :(c[$nterm]))
 

--- a/test/codegen_tests.jl
+++ b/test/codegen_tests.jl
@@ -1,17 +1,17 @@
 @testset "monomial_product" begin
-    @test SP.monomial_product(Float64, [2, 3, 1], :(c[5])) == :(c[5] * (x[1] * x[1]) * (x[2] * x[2] * x[2]) * x[3])
-    @test SP.monomial_product(Float64, [2, 3, 1], :(c[5]), 2) == :((3 * c[5] * (x[1] * x[1]) * (x[2] * x[2])) * x[3])
+    @test SP.monomial_product(Float64, [2, 3, 1], :(c[5]))[1] == :(c[5] * (x[1] * x[1]) * (x[2] * x[2] * x[2]) * x[3])
+    @test SP.monomial_product(Float64, [2, 3, 1], :(c[5]), 2)[1] == :((3 * c[5] * (x[1] * x[1]) * (x[2] * x[2])) * x[3])
 
     # optimizations
     # no ^1
-    @test SP.monomial_product(Float64, [1, 3, 1], :(c[5])) == :(c[5] * x[1] * (x[2] * x[2] * x[2]) * x[3])
+    @test SP.monomial_product(Float64, [1, 3, 1], :(c[5]))[1] == :(c[5] * x[1] * (x[2] * x[2] * x[2]) * x[3])
     # omit ^0
-    @test SP.monomial_product(Float64, [1, 0, 1], :(c[5])) == :(c[5] * x[1] * x[3])
-    @test SP.monomial_product(Float64, [0, 0, 0], :(c[5])) == :(c[5])
+    @test SP.monomial_product(Float64, [1, 0, 1], :(c[5]))[1] == :(c[5] * x[1] * x[3])
+    @test SP.monomial_product(Float64, [0, 0, 0], :(c[5]))[1] == :(c[5])
     # omit 1 * and ^0
-    @test SP.monomial_product(Float64, [1, 3, 2], :(c[5]), 1) == :(c[5] * (x[2] * x[2] * x[2]) * (x[3] * x[3]))
+    @test SP.monomial_product(Float64, [1, 3, 2], :(c[5]), 1)[1] == :(c[5] * (x[2] * x[2] * x[2]) * (x[3] * x[3]))
     # omit ^1 in derivative
-    @test SP.monomial_product(Float64, [2, 2, 2], :(c[5]), 2) == :((2 * c[5] * (x[1] * x[1]) * x[2]) * (x[3] * x[3]))
+    @test SP.monomial_product(Float64, [2, 2, 2], :(c[5]), 2)[1] == :((2 * c[5] * (x[1] * x[1]) * x[2]) * (x[3] * x[3]))
 end
 
 @testset "evaluate_codegen low_level" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,6 @@ import DynamicPolynomials: @polyvar
 import MultivariatePolynomials
 const MP = MultivariatePolynomials
 using Compat.Test
-using Compat.LinearAlgebra
 
 include("codegen_tests.jl")
 include("basic_tests.jl")


### PR DESCRIPTION
I noticed an inefficiency in the gradient routine. It could (and did) happen that we evaluated polynomials where the leading coefficient was 0.